### PR TITLE
Minor: Rename 'Ethereum price' to 'Ether price'

### DIFF
--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -486,7 +486,7 @@
     <ion-item lines="none" *ngIf="(unit.pref != 'ETHER' && unit.pref != 'FINNEY') || currencyPipe != null">
 
       <ion-label class="stat-title">
-        Ethereum Price
+        Ether Price
       </ion-label>
       <ion-label class="value" (click)="switchCurrencyPipe()">
         {{ 1 | mcurrency: "ETHER":unit.pref }}


### PR DESCRIPTION
 Just a nitpick: Ethereum is the name of the network. Ether (ETH) is the
 currency powering the network, which has the given market value.