### PR TITLE
search: support for ens domains

### DIFF
--- a/src/app/requests/requests.ts
+++ b/src/app/requests/requests.ts
@@ -238,6 +238,11 @@ export interface NotificationGetResponse {
   EventThreshold: string,
 }
 
+export interface GetAddressForEnsResponse {
+  address: string
+  domain: string
+}
+
 // ------------- Reqests -------------
 
 export class DashboardRequest extends APIRequest<DashboardResponse> {
@@ -353,6 +358,16 @@ export class EpochRequest extends APIRequest<EpochResponse> {
       this.ignoreFails = true
     }
     this.resource += epoch;
+  }
+}
+
+export class GetAddressForEnsRequest extends APIRequest<GetAddressForEnsResponse> {
+  resource = "ens/domain_lookup/"
+  method = Method.GET;
+
+  constructor(domain: string) {
+    super()
+    this.resource += domain
   }
 }
 

--- a/src/app/tab-validators/tab-validators.page.html
+++ b/src/app/tab-validators/tab-validators.page.html
@@ -38,7 +38,7 @@
 
   <ion-toolbar [style.--background]="selectMode ? 'var(--ion-color-primary)' : 'var(--ion-toolbar-background)'">
     <ion-searchbar *ngIf="!selectMode" showCancelButton="focus" enterkeyhint="search" (search)="searchEvent($event)"
-      (ionClear)="cancelSearch()" (ionCancel)="cancelSearch()" placeholder="Public Key / Index / ETH1 Address" animated>
+      (ionClear)="cancelSearch()" (ionCancel)="cancelSearch()" placeholder="Public Key / Index / ETH1 Address / ENS" animated>
     </ion-searchbar>
    
 
@@ -100,14 +100,14 @@
     <ion-icon name="telescope-outline"></ion-icon>
     <h2 >Nothing found</h2>
     <ion-label >We couldn't find the validators you are looking for.
-      Try searching by Index, Public Key or ETH1 address.</ion-label>
+      Try searching by Index, Public Key, ENS domain or ETH1 address.</ion-label>
   </div>
 
   <div class="nothingfound" *ngIf="items && items.length <= 0 && !searchResultMode && !loading && initialized">
     <ion-icon name="arrow-up-circle-outline"></ion-icon>
     <h2>Add Validators</h2>
     <ion-label >
-      You can add your validators by searching for a public key, validator index or your eth 1 address.
+      You can add your validators by searching for a public key, validator index, or your ETH1 address / ENS domain.
     </ion-label>
   </div>
 

--- a/src/app/utils/EnsUtils.ts
+++ b/src/app/utils/EnsUtils.ts
@@ -1,0 +1,51 @@
+// Copyright (C) 2021 Bitfly GmbH
+// 
+// This file is part of Beaconchain Dashboard.
+// 
+// Beaconchain Dashboard is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Beaconchain Dashboard is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Beaconchain Dashboard.  If not, see <http://www.gnu.org/licenses/>.
+
+import { ApiService } from "../services/api.service";
+import { Injectable } from '@angular/core';
+import { GetAddressForEnsRequest } from "../requests/requests";
+
+
+export interface EnsRelationship {
+    domain: string
+    address: string
+}
+
+
+@Injectable({
+    providedIn: 'root'
+  })
+export default class EnsUtils {
+
+    constructor(
+        private api: ApiService,
+    ) { }
+
+    async getAddressForEns(domain: string): Promise<EnsRelationship[]> {
+        const request = new GetAddressForEnsRequest(domain)
+        const response = await this.api.execute(request)
+        if (request.wasSuccessfull(response)) {
+            const result = request.parse(response)
+            return result
+        } else {
+            if (response && response.data && response.data.status) {
+                return Promise.reject(new Error(response.data.status))
+            }
+            return Promise.reject(new Error("Response is invalid"))
+        }
+    }
+}


### PR DESCRIPTION
Adds support for ens search with the help of a new endpoint added by https://github.com/gobitfly/eth2-beaconchain-explorer/pull/1458. Can be tested using `beacon1.eth`, assuming you point the app to an explorer instance with the above PR running.