### PR TITLE
logview: fix copy-to-clipboard button by using capacitor library

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':capacitor-community-http')
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
+    implementation project(':capacitor-clipboard')
     implementation project(':capacitor-device')
     implementation project(':capacitor-haptics')
     implementation project(':capacitor-keyboard')

--- a/android/app/src/main/assets/capacitor.plugins.json
+++ b/android/app/src/main/assets/capacitor.plugins.json
@@ -16,6 +16,10 @@
 		"classpath": "com.capacitorjs.plugins.browser.BrowserPlugin"
 	},
 	{
+		"pkg": "@capacitor/clipboard",
+		"classpath": "com.capacitorjs.plugins.clipboard.ClipboardPlugin"
+	},
+	{
 		"pkg": "@capacitor/device",
 		"classpath": "com.capacitorjs.plugins.device.DevicePlugin"
 	},

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -14,6 +14,9 @@ project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/
 include ':capacitor-browser'
 project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
 
+include ':capacitor-clipboard'
+project(':capacitor-clipboard').projectDir = new File('../node_modules/@capacitor/clipboard/android')
+
 include ':capacitor-device'
 project(':capacitor-device').projectDir = new File('../node_modules/@capacitor/device/android')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2335,6 +2335,11 @@
         }
       }
     },
+    "@capacitor/clipboard": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/clipboard/-/clipboard-4.0.1.tgz",
+      "integrity": "sha512-DO5fC6ax5Tm/4K77NjxRLu/bdyvO6FDCK38w05CE4LHvi3RF4LTM8EgnmIrEGKxwwbH5VloTeca9Cu6bsMXPiA=="
+    },
     "@capacitor/core": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-3.6.0.tgz",
@@ -3825,6 +3830,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.0.3",
@@ -6575,6 +6590,13 @@
         "escape-string-regexp": "^1.0.5"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -9271,6 +9293,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.3.4",
@@ -14964,7 +14993,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@capacitor/android": "^3.6.0",
     "@capacitor/app": "^1.0.6",
     "@capacitor/browser": "^1.0.7",
+    "@capacitor/clipboard": "^4.0.1",
     "@capacitor/core": "^3.6.0",
     "@capacitor/device": "^1.0.6",
     "@capacitor/haptics": "^1.1.4",

--- a/src/app/pages/logview/logview.page.ts
+++ b/src/app/pages/logview/logview.page.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { ModalController } from '@ionic/angular';
 import { Toast } from '@capacitor/toast';
+import { Clipboard } from '@capacitor/clipboard';
 
 @Component({
   selector: 'app-logview',
@@ -43,14 +44,24 @@ export class LogviewPage implements OnInit {
   }
 
   copyToClipboard() {
-    var result = ""
+    var result = "```\n"
     this.logs.forEach(data => {
       result += data.text +"\n"+data.extra
     })
-    navigator.clipboard.writeText(result);
-    Toast.show({
-      text: 'Copied to clipboard'
-    });
+    result += "\n```"
+    Clipboard
+      .write({string: result})
+      .then(() => {
+        Toast.show({
+          text: 'Copied to clipboard'
+        });
+      })
+      .catch((err) => {
+        Toast.show({
+          text: 'Failed to copy to clipboard, please copy manually!'
+        });
+        console.error(err)
+      });
   }
 
 }


### PR DESCRIPTION
`navigator.clipboard.writeText` doesn't work due to the mobile webview not defining `navigator.permission`, causing a `NotAllowError: Write permission denied.` error. using the [capacitor/clipboard](https://capacitorjs.com/docs/apis/clipboard) library fixes this by correctly handling permission on mobile.