### PR TITLE
Fix sync committee messages (BIDS-1027)

### DIFF
--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -134,11 +134,10 @@ export class DashboardComponent implements OnInit {
       if (event.data.currentValue) {
         this.chartError = false
         this.chartData = null
-        this.doneLoading = event.data.currentValue != null
-          this.fadeIn = "fade-in"
-          setTimeout(() => {
-            this.fadeIn = null
-          }, 1500)
+        this.fadeIn = "fade-in"
+        setTimeout(() => {
+          this.fadeIn = null
+        }, 1500)
 
         this.updateRplDisplay()
         this.drawBalanceChart()
@@ -150,50 +149,55 @@ export class DashboardComponent implements OnInit {
         this.updateRplProjectedClaim()
         this.updateSmoothingPool()
         this.updateActiveSyncCommitteeMessage(this.data.currentSyncCommittee)
-        this.updateNextyncCommitteeMessage(this.data.nextSyncCommittee)
+        this.updateNextSyncCommitteeMessage(this.data.nextSyncCommittee)
+        this.doneLoading = true
         console.log("dashboard data", this.data)
 
         if (!this.data.foreignValidator) {
           this.checkForFinalization()
-        
           this.checkForGenesisOccured()
         }
       }
     }
   }
 
-  async epochToTimestamp(epoch : number) {
+  async epochToTimestamp(epoch: number) {
     let network = await this.api.getNetwork()
     return (network.genesisTs + (epoch * 32 * 12)) * 1000
   }
 
   async updateActiveSyncCommitteeMessage(committee: SyncCommitteeResponse) {
-    if(!committee) return
-    let endTs = await this.epochToTimestamp(committee.end_epoch)
-    let startTs = await this.epochToTimestamp(committee.start_epoch)
-    this.currentSyncCommitteeMessage = {
-      title: "Sync Committee",
-      text: `Your validator${committee.validators.length > 1 ? 's': ''} ${committee.validators.toString()} ${committee.validators.length > 1 ? 'are': 'is'} currently part of the active sync committee.
+    if (committee) {
+      let endTs = await this.epochToTimestamp(committee.end_epoch)
+      let startTs = await this.epochToTimestamp(committee.start_epoch)
+      this.currentSyncCommitteeMessage = {
+        title: "Sync Committee",
+        text: `Your validator${committee.validators.length > 1 ? 's' : ''} ${committee.validators.toString()} ${committee.validators.length > 1 ? 'are' : 'is'} currently part of the active sync committee.
       <br/><br/>This duty started at epoch ${committee.start_epoch} at ${new Date(startTs).toLocaleString()} and 
       will end at epoch ${committee.end_epoch} at ${new Date(endTs).toLocaleString()}. 
       <br/><br/>You'll earn extra rewards during this period.
       `
-    } as SyncCommitteeMessage
+      } as SyncCommitteeMessage
+    } else {
+      this.currentSyncCommitteeMessage = null
+    }
   }
 
-
-  async updateNextyncCommitteeMessage(committee: SyncCommitteeResponse) {
-    if(!committee) return
-    let endTs = await this.epochToTimestamp(committee.end_epoch)
-    let startTs = await this.epochToTimestamp(committee.start_epoch)
-    this.nextSyncCommitteeMessage = {
-      title: "Sync Committee Soon",
-      text: `Your validator${committee.validators.length > 1 ? 's': ''} ${committee.validators.toString()} ${committee.validators.length > 1 ? 'are': 'is'} part of the <strong>next</strong> sync committee.
+  async updateNextSyncCommitteeMessage(committee: SyncCommitteeResponse) {
+    if (committee) {
+      let endTs = await this.epochToTimestamp(committee.end_epoch)
+      let startTs = await this.epochToTimestamp(committee.start_epoch)
+      this.nextSyncCommitteeMessage = {
+        title: "Sync Committee Soon",
+        text: `Your validator${committee.validators.length > 1 ? 's' : ''} ${committee.validators.toString()} ${committee.validators.length > 1 ? 'are' : 'is'} part of the <strong>next</strong> sync committee.
       <br/><br/>This duty starts at epoch ${committee.start_epoch} at ${new Date(startTs).toLocaleString()} and 
       will end at epoch ${committee.end_epoch} at ${new Date(endTs).toLocaleString()}. 
       <br/><br/>You'll earn extra rewards during this period.
       `
-    } as SyncCommitteeMessage
+      } as SyncCommitteeMessage
+    } else {
+      this.nextSyncCommitteeMessage = null
+    }
   }
 
   updateSmoothingPool() {
@@ -201,14 +205,14 @@ export class DashboardComponent implements OnInit {
       this.hasNonSmoothingPoolAsWell = this.data.rocketpool.hasNonSmoothingPoolAsWell
       this.displaySmoothingPool = this.data.rocketpool.smoothingPool
       this.smoothingClaimed = this.data.rocketpool.smoothingPoolClaimed.dividedBy(new BigNumber("1e9")),
-      this.smoothingUnclaimed = this.data.rocketpool.smoothingPoolUnclaimed.dividedBy(new BigNumber("1e9")),
-      this.unclaimedRpl = this.data.rocketpool.rplUnclaimed
+        this.smoothingUnclaimed = this.data.rocketpool.smoothingPoolUnclaimed.dividedBy(new BigNumber("1e9")),
+        this.unclaimedRpl = this.data.rocketpool.rplUnclaimed
     } catch (e) {
-      
+
     }
   }
 
-  updateRplProjectedClaim(){
+  updateRplProjectedClaim() {
     try {
       /*const inflationIntervalRate = new BigNumber("1000133680617113500")
       const hoursToAdd = this.validatorUtils.rocketpoolStats.claim_interval_time.split(":")[0]
@@ -233,16 +237,16 @@ export class DashboardComponent implements OnInit {
         .multipliedBy(new BigNumber(this.validatorUtils.rocketpoolStats.node_operator_rewards))
 
       this.rplProjectedClaim = temp
-      if(temp.isLessThanOrEqualTo(new BigNumber("0"))) { this.rplProjectedClaim = null }
-     
+      if (temp.isLessThanOrEqualTo(new BigNumber("0"))) { this.rplProjectedClaim = null }
+
     } catch {
-      
+
     }
   }
 
   getEffectiveRplStake(data: Rocketpool): BigNumber {
     if (data.currentRpl.isGreaterThanOrEqualTo(data.maxRpl)) return data.maxRpl
-    if(data.currentRpl.isLessThanOrEqualTo(data.minRpl)) return data.minRpl
+    if (data.currentRpl.isLessThanOrEqualTo(data.minRpl)) return data.minRpl
     return data.currentRpl
   }
 
@@ -255,7 +259,7 @@ export class DashboardComponent implements OnInit {
         .dividedBy(new BigNumber(hoursNumber / 24))
         .multipliedBy(new BigNumber(36500)).decimalPlaces(2).toFixed()
     } catch (e) {
-      
+
     }
   }
 
@@ -263,18 +267,18 @@ export class DashboardComponent implements OnInit {
     try {
       this.rplCommission = Math.round(this.validatorUtils.rocketpoolStats.current_node_fee * 10000) / 100
     } catch (e) {
-      
+
     }
   }
 
   updateNextRewardRound() {
     try {
-      const hoursToAdd =  this.validatorUtils.rocketpoolStats.claim_interval_time.split(":")[0]
-      this.nextRewardRound = this.validatorUtils.rocketpoolStats.claim_interval_time_start * 1000 + parseInt(hoursToAdd) * 60 * 60 * 1000 
+      const hoursToAdd = this.validatorUtils.rocketpoolStats.claim_interval_time.split(":")[0]
+      this.nextRewardRound = this.validatorUtils.rocketpoolStats.claim_interval_time_start * 1000 + parseInt(hoursToAdd) * 60 * 60 * 1000
     } catch (e) {
-      
+
     }
-   
+
   }
 
   ngOnInit() {
@@ -307,7 +311,7 @@ export class DashboardComponent implements OnInit {
     if (!this.data || !this.data.currentEpoch || !olderResult) return
     console.log("checkForFinalization", olderResult)
     this.finalizationIssue = new BigNumber(olderResult.globalparticipationrate).isLessThan("0.664") && olderResult.epoch > 7
-    this.storage.setObject("finalization_issues", { ts: Date.now(), value: this.finalizationIssue})
+    this.storage.setObject("finalization_issues", { ts: Date.now(), value: this.finalizationIssue })
   }
 
   async getChartData(data: ('allbalances' | 'proposals')) {
@@ -338,7 +342,7 @@ export class DashboardComponent implements OnInit {
       this.unit.pref = UnitconvService.currencyPipe
     }
     else {
-      UnitconvService.currencyPipe= this.unit.pref
+      UnitconvService.currencyPipe = this.unit.pref
       this.unit.pref = "ETHER"
     }
   }
@@ -354,7 +358,7 @@ export class DashboardComponent implements OnInit {
     }
   }
 
-  
+
   switchRplStake(canPercent = false) {
     if (this.rplState == "rpl" && canPercent) {
       // next %
@@ -362,7 +366,7 @@ export class DashboardComponent implements OnInit {
       this.updateRplDisplay()
       this.storage.setItem("rpl_pdisplay_mode", this.rplState)
       return
-    } else if ((this.rplState == "rpl" && !canPercent )|| this.rplState == "%") {
+    } else if ((this.rplState == "rpl" && !canPercent) || this.rplState == "%") {
       // next %
       this.rplState = "conv"
       this.updateRplDisplay()
@@ -437,12 +441,10 @@ export class DashboardComponent implements OnInit {
 
     if (!this.chartData || this.chartData.length < 3) {
       this.chartError = true;
-      this.doneLoading = true
       return
     }
 
     this.chartError = false;
-    setTimeout(() => { this.doneLoading = true }, 50)
 
     this.createBalanceChart(
       this.chartData.consensusChartData,
@@ -560,7 +562,7 @@ export class DashboardComponent implements OnInit {
       },
       xAxis: {
 
-       // tickInterval: 24 * 3600 * 1000,
+        // tickInterval: 24 * 3600 * 1000,
         //tickmarkPlacement: 'on',
 
         range: 32 * 24 * 60 * 60 * 1000,
@@ -575,7 +577,7 @@ export class DashboardComponent implements OnInit {
           var add = ``
 
           for (var i = 0; i < this.points.length; i++) {
-              add += `<span style="display: inline-block; width: 130px;">${this.points[i].series.name}: </span><b>${this.points[i].y.toFixed(5)} ETH </b><br/>`
+            add += `<span style="display: inline-block; width: 130px;">${this.points[i].series.name}: </span><b>${this.points[i].y.toFixed(5)} ETH </b><br/>`
           }
           return add
         }
@@ -583,8 +585,8 @@ export class DashboardComponent implements OnInit {
       navigator: {
         enabled: true,
         series: {
-            data: income,
-            color: '#7cb5ec',
+          data: income,
+          color: '#7cb5ec',
         }
       },
       plotOptions: {
@@ -622,7 +624,7 @@ export class DashboardComponent implements OnInit {
       ],
       series: [
         {
-      
+
           name: 'Consensus',
           data: income,
           index: 2

--- a/src/app/utils/ValidatorSyncUtils.ts
+++ b/src/app/utils/ValidatorSyncUtils.ts
@@ -23,7 +23,7 @@ import { StorageService } from '../services/storage.service';
 import { Injectable } from '@angular/core';
 import { MyValidatorResponse, AddMyValidatorsRequest } from '../requests/requests';
 import { Mutex } from 'async-mutex';
-import { ValidatorUtils, LAST_TIME_ADDED_KEY, LAST_TIME_REMOVED_KEY} from './ValidatorUtils';
+import { ValidatorUtils, LAST_TIME_ADDED_KEY, LAST_TIME_REMOVED_KEY } from './ValidatorUtils';
 
 const LAST_TIME_UPSYNCED_KEY = "last_time_upsynced"
 const LAST_TIME_UPDELETED_KEY = "last_time_updeleted"
@@ -55,7 +55,7 @@ export class ValidatorSyncUtils {
 
         const loggedIn = await this.storage.isLoggedIn()
         if (!loggedIn) return
-        console.log("[SYNC] sincing down")
+        console.log("[SYNC] syncing down")
 
         const myRemotes = await this.validator.getMyRemoteValidators()
         if (!myRemotes || myRemotes.length <= 0) return
@@ -71,8 +71,8 @@ export class ValidatorSyncUtils {
         }
 
         const newValidators = await this.validator.getRemoteValidatorInfo(newValidatorIndizes).catch((err) => { return null })
-        if (newValidators == null) return 
-        
+        if (newValidators == null) return
+
         this.validator.convertToValidatorModelsAndSaveLocal(true, newValidators)
     }
 
@@ -173,7 +173,7 @@ export class ValidatorSyncUtils {
 
 
     private async syncUp(syncNotificationsForNewValidators: () => void) {
-        console.log("[SYNC] sincing up")
+        console.log("[SYNC] syncing up")
 
         const storageKey = await this.validator.getStorageKey()
         const current = await this.validator.getMap(storageKey)

--- a/src/app/utils/ValidatorUtils.ts
+++ b/src/app/utils/ValidatorUtils.ts
@@ -59,9 +59,9 @@ export interface Validator {
     attrEffectiveness: number
     rocketpool: RocketPoolResponse
     execution: ExecutionResponse
-    share: number 
+    share: number
     rplshare: number
-    execshare: number 
+    execshare: number
     currentSyncCommittee: SyncCommitteeResponse
     nextSyncCommittee: SyncCommitteeResponse
 }
@@ -122,7 +122,7 @@ export class ValidatorUtils extends CacheModule {
         return new Map<String, Validator>()
     }
 
-    private async getMapWithoutDeleted(storageKey) : Promise<Map<String, Validator>> {
+    private async getMapWithoutDeleted(storageKey): Promise<Map<String, Validator>> {
         const local = await this.getMap(storageKey)
         const deleted = await this.getDeletedSet(storageKey)
         if (await this.storage.isLoggedIn()) {
@@ -177,6 +177,7 @@ export class ValidatorUtils extends CacheModule {
         console.log("delete set", deletedList)
 
         this.storage.setObject(LAST_TIME_REMOVED_KEY, { timestamp: Date.now() })
+        this.notifyListeners()
     }
 
     async saveValidatorsLocal(validators: Validator[]) {
@@ -190,7 +191,7 @@ export class ValidatorUtils extends CacheModule {
         })
 
         current.forEach((value, key) => {
-            if(!newMap.has(key)) newMap.set(key, value)
+            if (!newMap.has(key)) newMap.set(key, value)
         })
 
         this.storage.setObject(storageKey, newMap)
@@ -218,7 +219,7 @@ export class ValidatorUtils extends CacheModule {
         return erg
     }
 
-    async getLocalValidatorByIndex(index: number) : Promise<Validator> {
+    async getLocalValidatorByIndex(index: number): Promise<Validator> {
         let localValidators = await this.getAllValidatorsLocal()
         for (const vali of localValidators) {
             if (vali.index == index) {
@@ -228,32 +229,32 @@ export class ValidatorUtils extends CacheModule {
         return null
     }
 
-    async getLocalValidatorIndexes() : Promise<string> {
+    async getLocalValidatorIndexes(): Promise<string> {
         const storageKey = await this.getStorageKey()
         const local = await this.getMapWithoutDeleted(storageKey)
-      
-       return getValidatorQueryString([...local.values()], 2000, await this.merchantUtils.getCurrentPlanMaxValidator() - 1)
+
+        return getValidatorQueryString([...local.values()], 2000, await this.merchantUtils.getCurrentPlanMaxValidator() - 1)
     }
 
 
     async getAllMyValidators(): Promise<Validator[]> {
         const storageKey = await this.getStorageKey()
         const local = await this.getMapWithoutDeleted(storageKey)
-      
+
         const validatorString = getValidatorQueryString([...local.values()], 2000, await this.merchantUtils.getCurrentPlanMaxValidator() - 1)
 
         // TODO::
-       /* const cached = await this.getMultipleCached(allMyKeyBare, validatorString.split(","))
-        if (cached != null) {
-            console.log("return my validators from cache")
-            return cached
-        }*/
+        /* const cached = await this.getMultipleCached(allMyKeyBare, validatorString.split(","))
+         if (cached != null) {
+             console.log("return my validators from cache")
+             return cached
+         }*/
 
         const remoteUpdatesPromise = this.getDashboardDataValidators(SAVED,
             validatorString
         ).catch(err => { return [] })
         if (remoteUpdatesPromise == null) return null
-        
+
         const remoteUpdates = await remoteUpdatesPromise
 
         remoteUpdates.forEach((item) => {
@@ -292,7 +293,7 @@ export class ValidatorUtils extends CacheModule {
 
         return result
     }
-    
+
     getValidatorState(item: Validator, currentEpoch: EpochResponse): ValidatorState {
         if (item.data.slashed == false &&
             item.data.lastattestationslot >= (currentEpoch.epoch - 2) * 32 && // online since last two epochs
@@ -336,7 +337,7 @@ export class ValidatorUtils extends CacheModule {
 */
         const request = new DashboardRequest(validators)
         const response = await this.api.execute(request)
-       
+
         if (!request.wasSuccessfull(response)) {
             if (response && response.data && response.data.status && response.data.status.indexOf("only a maximum of") >= 0) {
                 throw new Error(response.data.status);
@@ -352,10 +353,10 @@ export class ValidatorUtils extends CacheModule {
         this.rocketpoolStats = result.rocketpool_network_stats[0]
         const validatorEffectivenessResponse = result.effectiveness
         const validatorsResponse = result.validators
- 
+
         this.updateRplAndRethPrice()
 
-        if (response.cached != true) { 
+        if (response.cached != true) {
             await this.storage.setLastEpochRequestTime(Date.now())
         } else {
             const lastCachedTime = await this.storage.getLastEpochRequestTime()
@@ -383,20 +384,20 @@ export class ValidatorUtils extends CacheModule {
             if (vali.rocketpool) {
                 vali.rplshare = await this.getRocketpoolCollateralShare(vali.rocketpool.node_address)
             }
-  
+
             if (result.current_sync_committee && result.current_sync_committee.length >= 1) {
                 vali.currentSyncCommittee = this.findSyncCommitteeDuty(result.current_sync_committee[0], vali.index)
-            } 
+            }
             if (result.next_sync_committee && result.next_sync_committee.length >= 1) {
                 vali.nextSyncCommittee = this.findSyncCommitteeDuty(result.next_sync_committee[0], vali.index)
             }
         }
 
-       // this.cacheMultiple(cacheKey, temp)
+        // this.cacheMultiple(cacheKey, temp)
         return temp
     }
 
-    private findSyncCommitteeDuty(committee: SyncCommitteeResponse, index: number ) : SyncCommitteeResponse{
+    private findSyncCommitteeDuty(committee: SyncCommitteeResponse, index: number): SyncCommitteeResponse {
         for (const vali of committee.validators) {
             if (vali == index) {
                 return committee
@@ -413,37 +414,37 @@ export class ValidatorUtils extends CacheModule {
 
 
     private findExecutionResponse(list: ExecutionResponse[], index: number): ExecutionResponse {
-        if(list == null || list.length == 0) return null
+        if (list == null || list.length == 0) return null
         for (let attr of list) {
             if (attr.validatorindex == index) {
-              return attr
+                return attr
             }
-          }
-          return null
+        }
+        return null
     }
 
     private findRocketpoolResponse(list: RocketPoolResponse[], index: number): RocketPoolResponse {
         for (let attr of list) {
-          if (attr.index == index) {
-            return attr
-          }
+            if (attr.index == index) {
+                return attr
+            }
         }
         return null
-      }
+    }
 
     private findAttributionEffectiveness(list: AttestationPerformanceResponse[], index: number): number {
         for (let attr of list) {
-          if (attr.validatorindex == index && attr.attestation_efficiency) {
-            return new BigNumber(1).dividedBy(attr.attestation_efficiency).multipliedBy(100).decimalPlaces(1).toNumber()
-          }
+            if (attr.validatorindex == index && attr.attestation_efficiency) {
+                return new BigNumber(1).dividedBy(attr.attestation_efficiency).multipliedBy(100).decimalPlaces(1).toNumber()
+            }
         }
         return -1
-      }
+    }
 
     async getOlderEpoch(): Promise<EpochResponse> {
         return this.olderEpoch
     }
-    
+
     async getRemoteCurrentEpoch(): Promise<EpochResponse> {
         const result = this.currentEpoch
         if (result == null) {
@@ -540,15 +541,16 @@ export class ValidatorUtils extends CacheModule {
     }
 
     async searchValidators(search: string): Promise<Validator[]> {
-        const result = await this.getDashboardDataValidators(MEMORY, search).catch(err => { 
-            return null })
-        if(result == null) return []
+        const result = await this.getDashboardDataValidators(MEMORY, search).catch(err => {
+            return null
+        })
+        if (result == null) return []
         return result
     }
 
     async searchValidatorsViaETH1(search: string, enforceMax: number = -1): Promise<Validator[]> {
         const result = await this.getRemoteValidatorViaETH1(search, enforceMax)
-        if(result == null) return []
+        if (result == null) return []
         return result
     }
 
@@ -588,7 +590,7 @@ export function getValidatorQueryString(validators: any[], getParamMaxLimit: num
     if (erg.length > 1) {
         return erg.substring(0, erg.length - 1)
     }
-    
+
     return erg
 }
 


### PR DESCRIPTION
- `updateActiveSyncCommitteeMessage` and `updateNextSyncCommitteeMessage` now delete the related messages if no committee is passed.
- Handling of `doneLoading` has been improved and now is set to true only by `async ngOnChanges(event)`.
- Removing a validator locally now notifies all `ValidatorUtils` listeners as well.
- Fixed typos (`updateNextyncCommitteeMessage` => `updateNextSyncCommitteeMessage` and `sincing` => `syncing`).