### PR TITLE
Apostrophes denote ownership

### DIFF
--- a/src/app/controllers/OverviewController.ts
+++ b/src/app/controllers/OverviewController.ts
@@ -572,8 +572,8 @@ export default class OverviewController {
 			icon: 'timer-outline',
 			title: activeValidatorCount + ' / ' + validatorCount,
 			description: this.descriptionSwitch(
-				pre + ' of your validators\' deposits are being processed',
-				'This validator\'s deposit is being processed',
+				pre + " of your validators' deposits are being processed",
+				"This validator's deposit is being processed",
 				foreignValidator
 			),
 			extendedDescriptionPre: estEta ? 'Estimated on ' : null,

--- a/src/app/controllers/OverviewController.ts
+++ b/src/app/controllers/OverviewController.ts
@@ -572,8 +572,8 @@ export default class OverviewController {
 			icon: 'timer-outline',
 			title: activeValidatorCount + ' / ' + validatorCount,
 			description: this.descriptionSwitch(
-				pre + ' of your validators deposits are being processed',
-				'This validators deposit is being processed',
+				pre + ' of your validators\' deposits are being processed',
+				'This validator\'s deposit is being processed',
 				foreignValidator
 			),
 			extendedDescriptionPre: estEta ? 'Estimated on ' : null,


### PR DESCRIPTION
Small grammar fix.

Form the possessive case of a plural noun by adding an apostrophe after the final letter if it is an s.
Form the possessive case of a singular noun by adding 's.