### PR TITLE
Bids 2006/validator rank via api

### DIFF
--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -724,7 +724,7 @@
 		<ion-label>General</ion-label>
 	</ion-list-header>
 
-	<ion-list class="performance">
+	<ion-list class="performance" *ngIf="data.bestRank != 0">
 		<ion-item lines="none" *ngIf="data.bestRank == data.worstRank">
 			<ion-label class="stat-title">
 				<span tooltip="Global rank of this validator, based on last 7 days" placement="right" trigger="click" hideDelayAfterClick="5000"> Rank </span>
@@ -734,7 +734,7 @@
 				<ion-icon name="ribbon-outline" class="rank-ribbon"></ion-icon>
 
 				<span class="rank-text">
-					{{ data.bestRank | percentageabs : data.currentEpoch.validatorscount : rankPercentMode : 'Top ' }}
+					{{ data.bestRank | percentageabs : data.bestTopX : rankPercentMode : 'Top ' }}
 				</span>
 			</ion-label>
 		</ion-item>
@@ -746,7 +746,7 @@
 						<ion-label class="value left">
 							<ion-icon name="ribbon-outline" class="rank-ribbon"></ion-icon>
 							<span class="rank-text">
-								{{ data.bestRank | percentageabs : data.currentEpoch.validatorscount : rankPercentMode : 'Top ' }}
+								{{ data.bestRank | percentageabs : data.bestTopX : rankPercentMode : 'Top ' }}
 							</span>
 						</ion-label>
 					</div>
@@ -768,7 +768,7 @@
 						<ion-label class="value">
 							<ion-icon name="ribbon-outline" class="rank-ribbon"></ion-icon>
 							<span class="rank-text">
-								{{ data.worstRank | percentageabs : data.currentEpoch.validatorscount : rankPercentMode : 'Top ' }}
+								{{ data.worstRank | percentageabs : data.worstTopX : rankPercentMode : 'Top ' }}
 							</span>
 						</ion-label>
 					</div>

--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -734,7 +734,7 @@
 				<ion-icon name="ribbon-outline" class="rank-ribbon"></ion-icon>
 
 				<span class="rank-text">
-					{{ data.bestRank | percentageabs : data.bestTopX : rankPercentMode : 'Top ' }}
+					{{ data.bestRank | percentageabs : data.bestTopPercentage : rankPercentMode : 'Top ' }}
 				</span>
 			</ion-label>
 		</ion-item>
@@ -746,7 +746,7 @@
 						<ion-label class="value left">
 							<ion-icon name="ribbon-outline" class="rank-ribbon"></ion-icon>
 							<span class="rank-text">
-								{{ data.bestRank | percentageabs : data.bestTopX : rankPercentMode : 'Top ' }}
+								{{ data.bestRank | percentageabs : data.bestTopPercentage : rankPercentMode : 'Top ' }}
 							</span>
 						</ion-label>
 					</div>
@@ -768,7 +768,7 @@
 						<ion-label class="value">
 							<ion-icon name="ribbon-outline" class="rank-ribbon"></ion-icon>
 							<span class="rank-text">
-								{{ data.worstRank | percentageabs : data.worstTopX : rankPercentMode : 'Top ' }}
+								{{ data.worstRank | percentageabs : data.worstTopPercentage : rankPercentMode : 'Top ' }}
 							</span>
 						</ion-label>
 					</div>

--- a/src/app/controllers/OverviewController.ts
+++ b/src/app/controllers/OverviewController.ts
@@ -200,9 +200,9 @@ export default class OverviewController {
 		const rankRelevantValidators = activeValidators.concat(offlineValidators)
 		if (rankRelevantValidators.length > 0) {
 			bestRank = findLowest(rankRelevantValidators, (cur) => cur.data.rank7d)
-			bestTopX = findLowest(rankRelevantValidators, (cur) => cur.data.rankPercentage)
+			bestTopX = findLowest(rankRelevantValidators, (cur) => cur.data.rankpercentage)
 			worstRank = findHighest(rankRelevantValidators, (cur) => cur.data.rank7d)
-			worstTopX = findHighest(rankRelevantValidators, (cur) => cur.data.rankPercentage)
+			worstTopX = findHighest(rankRelevantValidators, (cur) => cur.data.rankpercentage)
 		}
 
 		const rocketpoolValiCount = sumBigInt(validators, (cur) => (cur.rocketpool ? new BigNumber(1) : new BigNumber(0)))

--- a/src/app/controllers/OverviewController.ts
+++ b/src/app/controllers/OverviewController.ts
@@ -39,6 +39,8 @@ export type OverviewData = {
 	activationeligibilityCount: number
 	bestRank: number
 	worstRank: number
+	bestTopX: number
+	worstTopX: number
 	displayAttrEffectiveness: boolean
 	attrEffectiveness: number
 
@@ -173,6 +175,10 @@ export default class OverviewController {
 
 		let attrEffectiveness = 0
 		let displayAttrEffectiveness = false
+		let bestRank = 0
+		let bestTopX = 0
+		let worstRank = 0
+		let worstTopX = 0
 		if (activeValidators.length > 0) {
 			displayAttrEffectiveness = true
 
@@ -188,10 +194,13 @@ export default class OverviewController {
 				console.warn(`Effectiveness out of range: ${attrEffectiveness} (displaying "NaN")`)
 				attrEffectiveness = -1 // display "NaN" if something went wrong
 			}
+
+			bestRank = findLowest(activeValidators, (cur) => cur.data.rank7d)
+			bestTopX = findLowest(activeValidators, (cur) => cur.data.rankPercentage)
+			worstRank = findHighest(activeValidators, (cur) => cur.data.rank7d)
+			worstTopX = findHighest(activeValidators, (cur) => cur.data.rankPercentage)
 		}
 
-		const bestRank = findLowest(validators, (cur) => cur.data.rank7d)
-		const worstRank = findHighest(validators, (cur) => cur.data.rank7d)
 		const rocketpoolValiCount = sumBigInt(validators, (cur) => (cur.rocketpool ? new BigNumber(1) : new BigNumber(0)))
 		const feeSum = sumBigInt(validators, (cur) =>
 			cur.rocketpool ? new BigNumber(cur.rocketpool.minipool_node_fee).multipliedBy('100') : new BigNumber('0')
@@ -213,7 +222,9 @@ export default class OverviewController {
 			overallBalance: overallBalance,
 			validatorCount: validatorCount,
 			bestRank: bestRank,
+			bestTopX: bestTopX,
 			worstRank: worstRank,
+			worstTopX: worstTopX,
 			attrEffectiveness: attrEffectiveness,
 			displayAttrEffectiveness: displayAttrEffectiveness,
 			consensusPerformance: consensusPerf,

--- a/src/app/controllers/OverviewController.ts
+++ b/src/app/controllers/OverviewController.ts
@@ -159,6 +159,7 @@ export default class OverviewController {
 		const overallBalance = this.sumBigIntBalanceRP(validators, (cur) => new BigNumber(cur.data.balance))
 		const validatorCount = validators.length
 		const activeValidators = this.getActiveValidators(validators)
+		const offlineValidators = this.getOfflineValidators(validators)
 
 		const consensusPerf = this.getConsensusPerformance(validators, validatorDepositActive)
 
@@ -175,10 +176,6 @@ export default class OverviewController {
 
 		let attrEffectiveness = 0
 		let displayAttrEffectiveness = false
-		let bestRank = 0
-		let bestTopX = 0
-		let worstRank = 0
-		let worstTopX = 0
 		if (activeValidators.length > 0) {
 			displayAttrEffectiveness = true
 
@@ -194,11 +191,18 @@ export default class OverviewController {
 				console.warn(`Effectiveness out of range: ${attrEffectiveness} (displaying "NaN")`)
 				attrEffectiveness = -1 // display "NaN" if something went wrong
 			}
+		}
 
-			bestRank = findLowest(activeValidators, (cur) => cur.data.rank7d)
-			bestTopX = findLowest(activeValidators, (cur) => cur.data.rankPercentage)
-			worstRank = findHighest(activeValidators, (cur) => cur.data.rank7d)
-			worstTopX = findHighest(activeValidators, (cur) => cur.data.rankPercentage)
+		let bestRank = 0
+		let bestTopX = 0
+		let worstRank = 0
+		let worstTopX = 0
+		const rankRelevantValidators = activeValidators.concat(offlineValidators)
+		if (rankRelevantValidators.length > 0) {
+			bestRank = findLowest(rankRelevantValidators, (cur) => cur.data.rank7d)
+			bestTopX = findLowest(rankRelevantValidators, (cur) => cur.data.rankPercentage)
+			worstRank = findHighest(rankRelevantValidators, (cur) => cur.data.rank7d)
+			worstTopX = findHighest(rankRelevantValidators, (cur) => cur.data.rankPercentage)
 		}
 
 		const rocketpoolValiCount = sumBigInt(validators, (cur) => (cur.rocketpool ? new BigNumber(1) : new BigNumber(0)))
@@ -818,6 +822,12 @@ export default class OverviewController {
 	private getActiveValidators(validators: Validator[]) {
 		return validators.filter((item) => {
 			return item.state == ValidatorState.ACTIVE
+		})
+	}
+
+	private getOfflineValidators(validators: Validator[]) {
+		return validators.filter((item) => {
+			return item.state == ValidatorState.OFFLINE
 		})
 	}
 

--- a/src/app/controllers/OverviewController.ts
+++ b/src/app/controllers/OverviewController.ts
@@ -39,8 +39,8 @@ export type OverviewData = {
 	activationeligibilityCount: number
 	bestRank: number
 	worstRank: number
-	bestTopX: number
-	worstTopX: number
+	bestTopPercentage: number
+	worstTopPercentage: number
 	displayAttrEffectiveness: boolean
 	attrEffectiveness: number
 
@@ -194,15 +194,15 @@ export default class OverviewController {
 		}
 
 		let bestRank = 0
-		let bestTopX = 0
+		let bestTopPercentage = 0
 		let worstRank = 0
-		let worstTopX = 0
+		let worstTopPercentage = 0
 		const rankRelevantValidators = activeValidators.concat(offlineValidators)
 		if (rankRelevantValidators.length > 0) {
 			bestRank = findLowest(rankRelevantValidators, (cur) => cur.data.rank7d)
-			bestTopX = findLowest(rankRelevantValidators, (cur) => cur.data.rankpercentage)
+			bestTopPercentage = findLowest(rankRelevantValidators, (cur) => cur.data.rankpercentage)
 			worstRank = findHighest(rankRelevantValidators, (cur) => cur.data.rank7d)
-			worstTopX = findHighest(rankRelevantValidators, (cur) => cur.data.rankpercentage)
+			worstTopPercentage = findHighest(rankRelevantValidators, (cur) => cur.data.rankpercentage)
 		}
 
 		const rocketpoolValiCount = sumBigInt(validators, (cur) => (cur.rocketpool ? new BigNumber(1) : new BigNumber(0)))
@@ -226,9 +226,9 @@ export default class OverviewController {
 			overallBalance: overallBalance,
 			validatorCount: validatorCount,
 			bestRank: bestRank,
-			bestTopX: bestTopX,
+			bestTopPercentage: bestTopPercentage,
 			worstRank: worstRank,
-			worstTopX: worstTopX,
+			worstTopPercentage: worstTopPercentage,
 			attrEffectiveness: attrEffectiveness,
 			displayAttrEffectiveness: displayAttrEffectiveness,
 			consensusPerformance: consensusPerf,

--- a/src/app/pipes/percentageabs.pipe.ts
+++ b/src/app/pipes/percentageabs.pipe.ts
@@ -28,8 +28,13 @@ export class PercentageabsPipe implements PipeTransform {
 	transform(value_: number | BigNumber, percentage_: number | BigNumber, percentMode: boolean, preablePrct = ''): string {
 		if (percentMode) {
 			const percentage = percentage_ instanceof BigNumber ? percentage_ : new BigNumber(percentage_)
-			if (percentage.toNumber() <= 0.1) {
+			const percentageNumber = percentage.toNumber()
+			if (percentageNumber <= 0.1) {
 				return preablePrct + '0.1 %'
+			} else if (percentageNumber <= 1.0) {
+				return preablePrct + percentage.decimalPlaces(3).toString() + ' %'
+			} else if (percentageNumber <= 10.0) {
+				return preablePrct + percentage.decimalPlaces(2).toString() + ' %'
 			} else {
 				return preablePrct + percentage.decimalPlaces(1).toString() + ' %'
 			}

--- a/src/app/pipes/percentageabs.pipe.ts
+++ b/src/app/pipes/percentageabs.pipe.ts
@@ -25,17 +25,16 @@ import BigNumber from 'bignumber.js'
 	name: 'percentageabs',
 })
 export class PercentageabsPipe implements PipeTransform {
-	transform(value_: number | BigNumber, max_: number | BigNumber, percentMode: boolean, preablePrct = ''): string {
-		const value = value_ instanceof BigNumber ? value_ : new BigNumber(value_)
-		const max = max_ instanceof BigNumber ? max_ : new BigNumber(max_)
-
+	transform(value_: number | BigNumber, percentage_: number | BigNumber, percentMode: boolean, preablePrct = ''): string {
 		if (percentMode) {
-			let percentValue = value.dividedBy(max).multipliedBy(100).decimalPlaces(1)
-			if (percentValue.toNumber() <= 0.1) {
-				percentValue = value.dividedBy(max).multipliedBy(100).decimalPlaces(3)
+			const percentage = percentage_ instanceof BigNumber ? percentage_ : new BigNumber(percentage_)
+			if (percentage.toNumber() <= 0.1) {
+				return preablePrct + '0.1 %'
+			} else {
+				return preablePrct + percentage.decimalPlaces(1).toString() + ' %'
 			}
-			return preablePrct + percentValue.toString() + ' %'
 		} else {
+			const value = value_ instanceof BigNumber ? value_ : new BigNumber(value_)
 			return value.toFormat()
 		}
 	}

--- a/src/app/pipes/percentageabs.pipe.ts
+++ b/src/app/pipes/percentageabs.pipe.ts
@@ -25,19 +25,29 @@ import BigNumber from 'bignumber.js'
 	name: 'percentageabs',
 })
 export class PercentageabsPipe implements PipeTransform {
-	transform(value_: number | BigNumber, percentage_: number | BigNumber, percentMode: boolean, preablePrct = ''): string {
+	/**
+	 * Takes an absolute value (`value_`) and a relative percentage representation of it (`percentage_`  ) and returns a formatted string of one of those (based on `percentMode`).
+	 *
+	 * @param {number | BigNumber} value_ - The absolute value to be shown (used when `percentMode` is false).
+	 * @param {number | BigNumber} percentage_ - The relative percentage representation for the value (used when `percentMode` is true)
+	 * @param {boolean} percentMode - A flag indicating whether to use `value_` (false) or `percentage_` (true).
+	 * @param {string} [prefix=''] - An optional prefix to prepend to the resulting string if the absolute value is shown.
+	 * @returns {string} The formatted string.
+	 */
+	transform(value_: number | BigNumber, percentage_: number | BigNumber, percentMode: boolean, prefix = ''): string {
 		if (percentMode) {
 			const percentage = percentage_ instanceof BigNumber ? percentage_ : new BigNumber(percentage_)
 			const percentageNumber = percentage.toNumber()
 			if (percentageNumber <= 0.1) {
-				return preablePrct + '0.1 %'
-			} else if (percentageNumber <= 1.0) {
-				return preablePrct + percentage.decimalPlaces(3).toString() + ' %'
-			} else if (percentageNumber <= 10.0) {
-				return preablePrct + percentage.decimalPlaces(2).toString() + ' %'
-			} else {
-				return preablePrct + percentage.decimalPlaces(1).toString() + ' %'
+				return prefix + '0.1 %'
 			}
+			let decimalPlaces = 1
+			if (percentageNumber < 1.0) {
+				decimalPlaces = 3
+			} else if (percentageNumber < 10.0) {
+				decimalPlaces = 2
+			}
+			return prefix + percentage.decimalPlaces(decimalPlaces).toString() + ' %'
 		} else {
 			const value = value_ instanceof BigNumber ? value_ : new BigNumber(value_)
 			return value.toFormat()

--- a/src/app/requests/requests.ts
+++ b/src/app/requests/requests.ts
@@ -182,8 +182,9 @@ export interface ValidatorResponse {
 	performance31d: BigNumber
 	performance365d: BigNumber
 	performance7d: BigNumber
-	rank7d: number
 	performancetotal: BigNumber
+	rank7d: number
+	rankPercentage: number
 }
 
 export interface AttestationPerformanceResponse {

--- a/src/app/requests/requests.ts
+++ b/src/app/requests/requests.ts
@@ -184,7 +184,7 @@ export interface ValidatorResponse {
 	performance7d: BigNumber
 	performancetotal: BigNumber
 	rank7d: number
-	rankPercentage: number
+	rankpercentage: number
 }
 
 export interface AttestationPerformanceResponse {


### PR DESCRIPTION
With this PR, the app now uses the validators' "Top X%" rank served by the dashboard API endpoint via https://github.com/gobitfly/eth2-beaconchain-explorer/pull/2511.
Furthermore, the handling has been unified with the explorer: Only ranks for active validators now are shown.