### PR TITLE
Set turboThreshold to 10000

### DIFF
--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -755,6 +755,9 @@ export class DashboardComponent implements OnInit {
 							],
 						},
 					},
+					series: {
+						turboThreshold: 10000,
+					},
 				},
 				yAxis: [
 					{


### PR DESCRIPTION
With this PR, the `turboThreshold` for the validator's income chart is set from the default value of `1000` to `10000`. This causes the income chart to be displayed properly for mainnet again (fyi, mainnet now has 1004 entries causing the chart not to show the Conensus data).