### PR TITLE
Fix max stake share for rockepool nodes with 8 ETH

### DIFF
--- a/src/app/tab-validators/tab-validators.page.ts
+++ b/src/app/tab-validators/tab-validators.page.ts
@@ -534,7 +534,9 @@ export class Tab2Page {
 		for (const val of validatorSubArray) {
 			let temp = new BigNumber(val.data.effectivebalance)
 			if (val.rocketpool) {
-				temp = temp.dividedBy(2)
+				const nodeBalance = new BigNumber(val.rocketpool.node_deposit_balance).dividedBy(1e9);
+				const partRatio = nodeBalance.dividedBy(temp);
+				temp = temp.multipliedBy(partRatio);
 			}
 			sum = sum.plus(temp)
 		}


### PR DESCRIPTION
Since the Atlas Rocketpool upgrade was introduced, the validators can only provide 8 ETH to make a minipool instead of 16 ETH. 

Here In the dashboard, it was assumed that if a validator is a Rocketpool one, its max share is always 16 ETH. So if a validator with 8 ETH tried to use the "Set Share" functionality, it ended up with the wrong share being calculated for him. For example - when setting the share to 6 ETH - the dashboard assumed that the validator's share is 37,5% instead of the correct value of 75%.